### PR TITLE
created ecr.tf to provision ecr repo for user_service

### DIFF
--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -1,0 +1,8 @@
+resource "aws_ecr_repository" "user_service" {
+  name                 = "user_service"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}


### PR DESCRIPTION
I tried to name the repo UserService so it looks similar to UserProfiles in dynamodb, but got fail apply due to capital letters

Also was not sure if I should have blended it in dynamodb.tf file or create separate.