### PR TITLE
Feature/iam

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,7 +1,12 @@
 name: "Terraform Plan"
 
+# on:
+#   pull_request:
+
 on:
-  pull_request:
+  push:
+    branches:
+      - Feature/Iam
 
 env:
   TF_CLOUD_ORGANIZATION: "03thomasmasak-testing"

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,12 +1,7 @@
 name: "Terraform Plan"
 
-# on:
-#   pull_request:
-
 on:
-  push:
-    branches:
-      - Feature/Iam
+  pull_request:
 
 env:
   TF_CLOUD_ORGANIZATION: "03thomasmasak-testing"

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -1,0 +1,56 @@
+resource "aws_iam_role" "iam_lambda_user_service" {
+  name               = "lambda-user-service-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_user_service_assume.json
+}
+
+data "aws_iam_policy_document" "lambda_user_service_assume" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+    principals {
+      type = "Service"
+      identifiers = [
+        "lambda.amazonaws.com",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_policy_add" {
+  role       = aws_iam_role.iam_lambda_user_service.name
+  policy_arn = aws_iam_policy.lambda_policy.arn
+}
+
+resource "aws_iam_policy" "lambda_policy" {
+  name   = "lambda-user-service-policy"
+  policy = data.aws_iam_policy_document.lambda_policy.json
+}
+
+data "aws_iam_policy_document" "lambda_policy" {
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    effect    = "Allow"
+    resources = ["*"]
+    sid       = "CreateCloudWatchLogs"
+  }
+}
+
+resource "aws_iam_role_policy" "dynamodb-lambda-policy" {
+  name   = "dynamodb-lambda-policy"
+  role   = aws_iam_role.iam_lambda_user_service.id
+  policy = data.aws_iam_policy_document.dynamodb_lambda_policy.json
+  }
+
+data "aws_iam_policy_document" "dynamodb_lambda_policy" {
+  statement {
+    actions = ["dynamodb:*"]
+    effect    = "Allow"
+    resources = [aws_dynamodb_table.user_profiles.arn]
+  }
+}

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -3,63 +3,18 @@ resource "aws_lambda_function" "user_service" {
   function_name = "user_service"
   package_type  = "Image"
   image_uri     = "${aws_ecr_repository.user_service.repository_url}:latest"
-  role          = aws_iam_role.lambda_user_service.arn
+  role          = aws_iam_role.iam_lambda_user_service.arn
   publish       = true
 
   memory_size = 128
   timeout     = 28
 
   lifecycle {
-    ignore_changes = [
-      image_uri, last_modified
-    ]
+    ignore_changes = [image_uri]
   }
 }
 
 resource "aws_cloudwatch_log_group" "lambda_user_service" {
   name              = "/aws/lambda/lambda_user_service"
   retention_in_days = 7
-}
-
-resource "aws_iam_role" "lambda_user_service" {
-  name               = "lambda-user-service-role"
-  assume_role_policy = data.aws_iam_policy_document.lambda_user_service_assume.json
-}
-
-data "aws_iam_policy_document" "lambda_user_service_assume" {
-  statement {
-    effect = "Allow"
-    actions = [
-      "sts:AssumeRole",
-    ]
-    principals {
-      type = "Service"
-      identifiers = [
-        "lambda.amazonaws.com",
-      ]
-    }
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "user_service" {
-  role       = aws_iam_role.lambda_user_service.name
-  policy_arn = aws_iam_policy.lambda_user_service_custom.arn
-}
-
-resource "aws_iam_policy" "lambda_user_service_custom" {
-  name   = "lambda-user-service-policy"
-  policy = data.aws_iam_policy_document.lambda_user_service_custom.json
-}
-
-data "aws_iam_policy_document" "lambda_user_service_custom" {
-  statement {
-    actions = [
-      "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents"
-    ]
-    effect    = "Allow"
-    resources = ["*"]
-    sid       = "CreateCloudWatchLogs"
-  }
 }

--- a/src/user_service.py
+++ b/src/user_service.py
@@ -1,32 +1,29 @@
-# import boto3
-# import json
-# import uuid
+import boto3
+import json
+import uuid
 
-# client = boto3.resource('dynamodb')
-# table = client.Table("UserProfiles")
-
-# def lambda_handler(event, context):
-#     command = event['command']
-#     command_map[command](event['payload'])
-
-# def create(user_data):
-#     user_data['id'] = uuid.uuid4()
-#     table.put_item(Item=user_data)
-#     # TODO: Also create Cognito user later
-
-# def update(user_data):
-#     table.put_item(Item=user_data)
-
-# def delete(user_data):
-#     table.delete_item(Key=user_data)
-#     # TODO: Also delete cognito user later
-
-
-# command_map = {
-#     "create": create,
-#     "update": update,
-#     "delete": delete
-# }
+client = boto3.resource('dynamodb')
+table = client.Table("UserProfiles")
 
 def lambda_handler(event, context):
-    return 'Hello AWS Lambda, test number 4'
+    command = event['command']
+    command_map[command](event['payload'])
+
+def create(user_data):
+    user_data['id'] = uuid.uuid4()
+    table.put_item(Item=user_data)
+    # TODO: Also create Cognito user later
+
+def update(user_data):
+    table.put_item(Item=user_data)
+
+def delete(user_data):
+    table.delete_item(Key=user_data)
+    # TODO: Also delete cognito user later
+
+
+command_map = {
+    "create": create,
+    "update": update,
+    "delete": delete
+}


### PR DESCRIPTION
We already created aws_iam_role for lambda in the last task. So, it was really just the dynamodb policy, or so I thought.

I took some elements from the source you linked but changed it instead of using "assume_role_policy = jsonencode" to its own data "aws_iam" blocks and linked them together, which apparently makes it more reuse friendly in the future. Looks a bit more complicated on the eye though...

I had to read properly through all the differences in aws_iam_*_policy, now I understand the difference between aws_iam_policy (managed policy that needs to be attached) and aws_iam_role_policy (inline policy only to this role) as after running tf apply I could not locate the latter. 

Also ran into tf cloud authorization issues, the TF_API_TOKEN, which we use to log into tf cloud to store state files, expires every 30 days on default, and even after updating repo secret it would not let me in. Had to manually modify ~/.terraform.d/credentials.tfrc.json with the new token.

There must be better way, I will look into it later.